### PR TITLE
turned on compiler optimizations by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ project(kodiak)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-add_definitions(-Wall -frounding-math -pedantic -Wextra -Wno-parentheses -g -O0)
+add_definitions(-Wall -frounding-math -pedantic -Wextra -Wno-parentheses -g -O3)
 
 
 ############################################################


### PR DESCRIPTION
Changes default compiler optimization level from `-O0` to `-O3` as discussed in issue #12